### PR TITLE
Basic UX improvements for OneClick installer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,10 @@ jobs:
         with:
           # Nerdbank.GitVersioning needs a full clone
           fetch-depth: 0
+      - uses: actions/checkout@v2
+        with:
+          repository: divvun/oneclick-bundler
+          path: oneclick-bundler
       - name: Setup Divvun CI
         uses: divvun/actions/setup@master
         with:
@@ -22,6 +26,17 @@ jobs:
         uses: dotnet/nbgv@master
         with:
           setCommonVars: true
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+          components: rust-src
+          target: i686-pc-windows-msvc
+      - uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: xargo
       - name: Get version
         id: version
         uses: divvun/actions/version@master
@@ -35,10 +50,11 @@ jobs:
           repo: https://pahkat.uit.no/devtools/
           channel: nightly
           packages: pahkat-uploader, pahkat-windows-cli, dotnet5-webinst
-      - name: Move dotnet5-webinst to appropriate place
+      - name: Move dotnet5-webinst to appropriate places
         run: |
           ls -R $env:RUNNER_TEMP\pahkat-prefix\pkg\dotnet5-webinst
           cp $env:RUNNER_TEMP\pahkat-prefix\pkg\dotnet5-webinst\bin\dotnet5-webinst.exe $env:RUNNER_WORKSPACE\divvun-manager-windows\
+          cp $env:RUNNER_TEMP\pahkat-prefix\pkg\dotnet5-webinst\bin\dotnet5-webinst.exe $env:RUNNER_WORKSPACE\divvun-manager-windows\oneclick-bundler\
       - name: Acquire Pahkat Service installer (nightly)
         if: ${{ steps.version.outputs.channel == 'nightly' }}
         run: |
@@ -59,6 +75,13 @@ jobs:
           call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           nuget restore "Divvun.Installer.sln"
           MSBuild.exe "Divvun.Installer.sln" /p:Configuration=Release /p:Platform=x86 /m  || exit /b !ERRORLEVEL!
+      - name: Package OneClick
+        shell: cmd
+        run: |
+          dotnet publish .\Divvun.Installer.OneClick\Divvun.Installer.OneClick.csproj /p:Platform=x86 /p:Configuration=Release
+          cp Divvun.Installer.OneClick/publish/Divvun.Installer.OneClick.exe oneclick-bundler\
+          cd oneclick-bundler
+          cargo xtask
       - name: Sign code (Divvun Manager exe)
         uses: divvun/actions/codesign@master
         with:
@@ -66,7 +89,7 @@ jobs:
       - name: Sign code (Divvun Installer OneClick exe)
         uses: divvun/actions/codesign@master
         with:
-          path: Divvun.Installer.OneClick/bin/Release/net5.0-windows/win-x86/Divvun.Installer.OneClick.exe
+          path: oneclick-bundler/target/dist/Divvun.Installer.OneClick.exe
       - name: Sign code (Pahkat SDK DLL)
         uses: divvun/actions/codesign@master
         with:
@@ -103,7 +126,7 @@ jobs:
           # This product code isn't actually used but is a mandatory field.
           windows-product-code: "divvun-manager-oneclick"
           version: ${{ steps.version.outputs.version }}
-          payload-path: Divvun.Installer.OneClick/bin/Release/net5.0-windows/win-x86/Divvun.Installer.OneClick.exe
+          payload-path: oneclick-bundler/target/dist/Divvun.Installer.OneClick.exe
           repo: https://pahkat.thetc.se/divvun-installer/
           channel: ${{ steps.version.outputs.channel }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Divvun.Installer.OneClick/MainWindow.xaml
+++ b/Divvun.Installer.OneClick/MainWindow.xaml
@@ -7,7 +7,6 @@
         mc:Ignorable="d"
         Loaded="MainWindow_OnLoaded"
         Closing="MainWindow_OnClosing"
-        ResizeMode="CanMinimize"
         Title="MainWindow" Height="350" Width="600">
     <Grid  VerticalAlignment="Center" HorizontalAlignment="Center">
         <Grid Name="PageLoading">
@@ -16,9 +15,9 @@
 
         <Grid Name="PageHome" Visibility="Hidden">
             <Grid.RowDefinitions>
-                <RowDefinition Height="*"></RowDefinition>
-                <RowDefinition Height="32"></RowDefinition>
-                <RowDefinition Height="128"></RowDefinition>
+                <RowDefinition Height="Auto"></RowDefinition>
+                <RowDefinition Height="Auto"></RowDefinition>
+                <RowDefinition Height="Auto"></RowDefinition>
             </Grid.RowDefinitions>
             <TextBlock Grid.Row="0" Text="Select Language to Install:" FontSize="36" FontWeight="SemiBold" TextAlignment="Center" TextWrapping="Wrap" Margin="0,0,0,64"></TextBlock>
             <ComboBox Grid.Row="1" Name="Languages" FontSize="17"
@@ -32,7 +31,7 @@
 
         <Grid Name="PageDownload" Visibility="Hidden">
             <Grid.RowDefinitions>
-                <RowDefinition Height="*"></RowDefinition>
+                <RowDefinition Height="Auto"></RowDefinition>
                 <RowDefinition Height="32"></RowDefinition>
                 <RowDefinition Height="32"></RowDefinition>
             </Grid.RowDefinitions>

--- a/Divvun.Installer.OneClick/MainWindow.xaml
+++ b/Divvun.Installer.OneClick/MainWindow.xaml
@@ -47,7 +47,14 @@
                 <RowDefinition Height="32"></RowDefinition>
             </Grid.RowDefinitions>
             <TextBlock Grid.Row="0" TextAlignment="Center" VerticalAlignment="Center" TextWrapping="Wrap" Text="That's it!" FontSize="36" FontWeight="SemiBold" Margin="0,0,0,64"></TextBlock>
-            <Button Grid.Row="1" Height="32" Name="RebootButton" Click="RebootButton_OnClick">Reboot Now</Button>
+            <Grid Grid.Row="1">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="1*" />
+                    <ColumnDefinition Width="1*" />
+                </Grid.ColumnDefinitions>
+                <Button Grid.Column="0" Height="32" Name="RebootButton" Click="RebootButton_OnClick" Margin="0,0,10,0">Reboot Now</Button>
+                <Button Grid.Column="1" Height="32" x:Name="RebootLaterButton" Click="RebootLaterButton_OnClick" Margin="10,0,0,0">Reboot Later</Button>
+            </Grid>
         </Grid>
     </Grid>
 </Window>

--- a/Divvun.Installer.OneClick/MainWindow.xaml.cs
+++ b/Divvun.Installer.OneClick/MainWindow.xaml.cs
@@ -149,7 +149,7 @@ namespace Divvun.Installer.OneClick
             // return JsonConvert.DeserializeObject<OneClickMeta>(jsonPayload);
             return new OneClickMeta()
             {
-                InstallerUrl = "https://pahkat.uit.no/artifacts/divvun-installer_2.0.0_windows.exe",
+                InstallerUrl = "https://pahkat.uit.no/artifacts/divvun-installer_2.2.0_windows.exe",
                 LanguageTags = new List<string> { "fo", "se", "sma", "smj", "smn", "sms", "crk", "srs" }
             };
         }
@@ -349,7 +349,7 @@ namespace Divvun.Installer.OneClick
 
         private void MainWindow_OnClosing(object sender, CancelEventArgs e)
         {
-            if (PageHome.Visibility == Visibility.Hidden)
+            if (PageDownload.Visibility == Visibility.Visible)
             {
                 e.Cancel = true;
                 ((Window) sender).WindowState = WindowState.Minimized;
@@ -359,6 +359,11 @@ namespace Divvun.Installer.OneClick
         private void RebootButton_OnClick(object sender, RoutedEventArgs e)
         {
             ShutdownExtensions.Reboot();
+        }
+
+        private void RebootLaterButton_OnClick(object sender, RoutedEventArgs e)
+        {
+            this.Close();
         }
     }
 


### PR DESCRIPTION
This PR contains basic improvements for the oneclick installer.

- Window can now be resized
- User has the choice to reboot later
- Installer does not require that .NET be installed on the system
- OneClick installer is actually a single file
- Installer has icon and manifest to prevent windows auto installer detection
    - Installer detection is annoying for end users since if the user chooses not to install windows will pop up a warning. And in some cases may pop up said warning even _if_ the user installed a language.