### PR TITLE
fix issue where the DM application wouldn't open from desktop if the …

### DIFF
--- a/Divvun.Installer/App.xaml.cs
+++ b/Divvun.Installer/App.xaml.cs
@@ -57,6 +57,9 @@ public partial class PahkatApp : Application, ISingleInstance {
     public Settings Settings { get; protected set; }
 
     public void OnInstanceInvoked(string[] args) {
+        Current.Dispatcher.Invoke(() => {
+            WindowService.Show<MainWindow>();
+        });
     }
 
     public async Task StartTransaction(PackageAction[] actions) {


### PR DESCRIPTION
…application was running in the system tray

Basically what the title says. The reason it didn't open was because we only allow one instance to be running at a time, therefore if the divvun manager was still running, but minimized, the application would say oh shoot we are already running, let's bail.

Fortunately the lib SingeInstanceCore that we are using, provides us with the function OnInstanceInvoked which is ran whenever another instance is initiated. From there we can show the window. But, we also need to use the Dispatcher, which I assume communicates the action to the correct thread, or something like that.
